### PR TITLE
Update Team.lua - Wow classic era

### DIFF
--- a/Core/Team.lua
+++ b/Core/Team.lua
@@ -1232,10 +1232,10 @@ function EMA.DoTeamPartyInvite()
 		--if GetTeamListMaximumOrderOnline() > 5 and EMA.db.inviteConvertToRaid == true then
 		if EMA.inviteCount > 4 and EMA.db.inviteConvertToRaid == true then
 			if EMA.db.inviteSetAllAssistant == true then	
-				C_PartyInfo.ConvertToRaid()
+				ConvertToRaid()
 				SetEveryoneIsAssistant(true)
 			else				
-				C_PartyInfo.ConvertToRaid()
+				ConvertToRaid()
 			end
 		end
 		EMA:ScheduleTimer( "DoTeamPartyInvite", 0.5 )


### PR DESCRIPTION
trying to call a function 'ConvertToRaid' from within the 'C_PartyInfo' table (or namespace). However, in Classic WoW, 'ConvertToRaid' is a global function and is not a part of the 'C_PartyInfo' namespace.