### PR TITLE
feat: add API compatibility layer for cross-version support

### DIFF
--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -10,6 +10,29 @@
 --																					--
 -- ================================================================================ --
 
+-------------------------------------------------------------------------------------------------------------
+-- API Compatibility Layer for cross-version support (Classic, TBC, Wrath, Cata, Retail)
+-------------------------------------------------------------------------------------------------------------
+
+local function GetAddOnMetadataCompat(name, field)
+	if C_AddOns and C_AddOns.GetAddOnMetadata then
+		return C_AddOns.GetAddOnMetadata(name, field)
+	elseif GetAddOnMetadata then
+		return GetAddOnMetadata(name, field)
+	end
+	return nil
+end
+
+local function IsAddOnLoadedCompat(name)
+	if C_AddOns and C_AddOns.IsAddOnLoaded then
+		return C_AddOns.IsAddOnLoaded(name)
+	elseif IsAddOnLoaded then
+		return IsAddOnLoaded(name)
+	end
+	return false
+end
+
+-------------------------------------------------------------------------------------------------------------
 -- The global private table for EMA.
 EMAPrivate = {}
 EMAPrivate.Core = {}


### PR DESCRIPTION
## What This Does
Adds compatibility wrapper functions for the C_AddOns API, which doesn't exist in TBC Classic but does in Retail WoW.

## Context
The current deployed version (v4.3) uses the older GetAddOnMetadata/IsAddOnLoaded API 
which works in TBC Classic. However, newer code in master uses C_AddOns namespace 
which doesn't exist in TBC, causing nil errors.

This PR adds a compatibility layer to support both APIs, allowing the addon to work 
across all WoW versions (Classic, TBC, Wrath, Cata, Retail).
## Why It's Needed
- TBC Anniversary uses older API (GetAddOnMetadata, IsAddOnLoaded as globals)
- Retail uses newer API (C_AddOns.GetAddOnMetadata, C_AddOns.IsAddOnLoaded)
- This wrapper detects which API is available and uses it

## How It Works
GetAddOnMetadataCompat and IsAddOnLoadedCompat check:
1. Does C_AddOns exist? Use it
2. Otherwise, use the global function
3. Return nil/false if neither available

## Files Changed
- Core/Core.lua (added compatibility layer)

## Next Steps
This is foundation for subsequent PRs that will use these wrappers throughout the codebase.