### PR TITLE
Fix/use compatibility functions

### DIFF
--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -10,6 +10,29 @@
 --																					--
 -- ================================================================================ --
 
+-------------------------------------------------------------------------------------------------------------
+-- API Compatibility Layer for cross-version support (Classic, TBC, Wrath, Cata, Retail)
+-------------------------------------------------------------------------------------------------------------
+
+local function GetAddOnMetadataCompat(name, field)
+	if C_AddOns and C_AddOns.GetAddOnMetadata then
+		return C_AddOns.GetAddOnMetadata(name, field)
+	elseif GetAddOnMetadata then
+		return GetAddOnMetadata(name, field)
+	end
+	return nil
+end
+
+local function IsAddOnLoadedCompat(name)
+	if C_AddOns and C_AddOns.IsAddOnLoaded then
+		return C_AddOns.IsAddOnLoaded(name)
+	elseif IsAddOnLoaded then
+		return IsAddOnLoaded(name)
+	end
+	return false
+end
+
+-------------------------------------------------------------------------------------------------------------
 -- The global private table for EMA.
 EMAPrivate = {}
 EMAPrivate.Core = {}

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -62,7 +62,7 @@ EMA.moduleIcon = "Interface\\Addons\\EMA\\Media\\NewsIcon.tga"
 EMA.pofileIcon = "Interface\\Addons\\EMA\\Media\\SettingsIcon.tga"
 -- order
 EMA.moduleOrder = 1
-local version =   C_AddOns.GetAddOnMetadata("EMA", "version")
+local version = GetAddOnMetadataCompat("EMA", "version")
 
 -- Load libraries.
 local AceGUI = LibStub("AceGUI-3.0")
@@ -87,7 +87,7 @@ EMAPrivate.SettingsFrame.Widget:AddChild( EMAPrivate.SettingsFrame.WidgetTree )
 
 
 function EMA:OnEnable()
-	local Jamba = C_AddOns.IsAddOnLoaded("Jamba")
+	local Jamba = IsAddOnLoadedCompat("Jamba")
 	if Jamba == true then
 		StaticPopup_Show( "CAN_NOT_RUN_JAMBA_AND_EMA" )
 	end
@@ -322,7 +322,7 @@ end
 
 --Ema Alpha
 local function isEmaAlphaBuild()
-	local EMAVersion = GetAddOnMetadata("EMA", "version")
+	local EMAVersion = GetAddOnMetadataCompat("EMA", "version")
 	-- EMA Alpha Build
 	local Alpha = EMAVersion:find( "Alpha" )
 	if Alpha then
@@ -883,3 +883,5 @@ EMAPrivate.Core.isEmaBetaBuild = isEmaBetaBuild
 EMAPrivate.Core.isEmaAlphaBuild = isEmaAlphaBuild
 EMAPrivate.Core.SendSettingsAllModules = EMA.SendSettingsAllModules
 EMAPrivate.Core.RefreshSettingsAllModules = EMA.RefreshSettingsAllModules
+EMAPrivate.Core.GetAddOnMetadata = GetAddOnMetadataCompat
+EMAPrivate.Core.IsAddOnLoaded = IsAddOnLoadedCompat


### PR DESCRIPTION
**Dependencies:** Requires PR #142 (feat: add API compatibility layer for cross-version support)

This PR updates Core.lua to use the compatibility functions introduced in PR #1...

Update [Core.lua](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use API compatibility functions

Use GetAddOnMetadataCompat for version detection
Use IsAddOnLoadedCompat for addon checks
Export compatibility functions in EMAPrivate.Core so other modules can use them
Depends on PR 142 (API compatibility layer) - https://github.com/ebonyfaye/ema/pull/142
Prepares for PR 144 (module fixes)

Tested on TBC Anniversary on 0230 - no regression
✅ PR #143 introduced no regressions
✅ PR #143 fixed the [Core.lua](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) issues (version detection works)
⏳ PR #144 will eliminate DisplayTeam (32x) + Quest-Classic (2x) IsAddOnLoaded errors
<img width="1203" height="251" alt="image" src="https://github.com/user-attachments/assets/728c4fe8-92a8-431f-9e1a-d707d81fdafc" />


---
To Verify settings still work:

Type /ema config
Settings window should open
Version should display correctly at the top
Expected result after PR #143:

No new errors introduced
Settings functional
Version displays
Important caveat: PR #143 won't eliminate the DisplayTeam.lua and Quest-Classic.lua errors yet (32x + 2x IsAddOnLoaded errors). Those are fixed by PR #144, which will use the compatibility function exports that PR #2 just created.

PR #143 success = "no regressions + settings work"
PR #144 success = "DisplayTeam & Quest-Classic errors gone"