### PR TITLE
Fix/update module api calls

### DIFF
--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -10,6 +10,29 @@
 --																					--
 -- ================================================================================ --
 
+-------------------------------------------------------------------------------------------------------------
+-- API Compatibility Layer for cross-version support (Classic, TBC, Wrath, Cata, Retail)
+-------------------------------------------------------------------------------------------------------------
+
+local function GetAddOnMetadataCompat(name, field)
+	if C_AddOns and C_AddOns.GetAddOnMetadata then
+		return C_AddOns.GetAddOnMetadata(name, field)
+	elseif GetAddOnMetadata then
+		return GetAddOnMetadata(name, field)
+	end
+	return nil
+end
+
+local function IsAddOnLoadedCompat(name)
+	if C_AddOns and C_AddOns.IsAddOnLoaded then
+		return C_AddOns.IsAddOnLoaded(name)
+	elseif IsAddOnLoaded then
+		return IsAddOnLoaded(name)
+	end
+	return false
+end
+
+-------------------------------------------------------------------------------------------------------------
 -- The global private table for EMA.
 EMAPrivate = {}
 EMAPrivate.Core = {}

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -62,7 +62,7 @@ EMA.moduleIcon = "Interface\\Addons\\EMA\\Media\\NewsIcon.tga"
 EMA.pofileIcon = "Interface\\Addons\\EMA\\Media\\SettingsIcon.tga"
 -- order
 EMA.moduleOrder = 1
-local version =   C_AddOns.GetAddOnMetadata("EMA", "version")
+local version = GetAddOnMetadataCompat("EMA", "version")
 
 -- Load libraries.
 local AceGUI = LibStub("AceGUI-3.0")
@@ -87,7 +87,7 @@ EMAPrivate.SettingsFrame.Widget:AddChild( EMAPrivate.SettingsFrame.WidgetTree )
 
 
 function EMA:OnEnable()
-	local Jamba = C_AddOns.IsAddOnLoaded("Jamba")
+	local Jamba = IsAddOnLoadedCompat("Jamba")
 	if Jamba == true then
 		StaticPopup_Show( "CAN_NOT_RUN_JAMBA_AND_EMA" )
 	end
@@ -322,7 +322,7 @@ end
 
 --Ema Alpha
 local function isEmaAlphaBuild()
-	local EMAVersion = GetAddOnMetadata("EMA", "version")
+	local EMAVersion = GetAddOnMetadataCompat("EMA", "version")
 	-- EMA Alpha Build
 	local Alpha = EMAVersion:find( "Alpha" )
 	if Alpha then
@@ -883,3 +883,5 @@ EMAPrivate.Core.isEmaBetaBuild = isEmaBetaBuild
 EMAPrivate.Core.isEmaAlphaBuild = isEmaAlphaBuild
 EMAPrivate.Core.SendSettingsAllModules = EMA.SendSettingsAllModules
 EMAPrivate.Core.RefreshSettingsAllModules = EMA.RefreshSettingsAllModules
+EMAPrivate.Core.GetAddOnMetadata = GetAddOnMetadataCompat
+EMAPrivate.Core.IsAddOnLoaded = IsAddOnLoadedCompat

--- a/Modules/DisplayTeam.lua
+++ b/Modules/DisplayTeam.lua
@@ -26,7 +26,7 @@ local EMAHelperSettings = LibStub:GetLibrary( "EMAHelperSettings-1.0" )
 local LibBagUtils = LibStub:GetLibrary( "LibBagUtils-1.0" )
 local LibButtonGlow = LibStub:GetLibrary( "LibButtonGlow-1.0" )
 EMA.SharedMedia = LibStub( "LibSharedMedia-3.0" )
-local TrufiGCD = C_AddOns.IsAddOnLoaded( "TrufiGCD" )
+local TrufiGCD = EMAPrivate.Core.IsAddOnLoaded( "TrufiGCD" )
 TrufiGCDGlSave = TrufiGCDGlSave
 
 
@@ -3260,7 +3260,7 @@ function EMA:UpdateSpellStatus( unitTarget, spellID )
 	local GCDFrame = characterStatusBar["GCDFrame"]	
 	local GCDFrameText = characterStatusBar["GCDFrameText"]
 	--EMA:Print("testUpdate", unitTarget )
-	if C_AddOns.IsAddOnLoaded( "TrufiGCD" ) == true then
+	if EMAPrivate.Core.IsAddOnLoaded( "TrufiGCD" ) == true then
 		local i, _ = TrGCDPlayerDetect(unitTarget)
 		--EMA:Print("test", unitTarget, i )
 		if i > 0 and i <= 5 then
@@ -3277,7 +3277,7 @@ function EMA:SetTrGCOpt()
 	if EMA.db.showTeamList == false and EMA.db.showGCDFrame == false then
 		return
 	end
-	if C_AddOns.IsAddOnLoaded( "TrufiGCD" ) == true then
+	if EMAPrivate.Core.IsAddOnLoaded( "TrufiGCD" ) == true then
 		local TimeGcd = 1.6
 		for i=1,5 do
 		-- enable

--- a/Modules/Quest-Classic.lua
+++ b/Modules/Quest-Classic.lua
@@ -1956,7 +1956,7 @@ function EMA:CreateEMAMiniQuestLogFrame()
 	frame:EnableMouse( true )
 	frame:SetMovable( true )	
 	frame:ClearAllPoints()
-	if IsAddOnLoaded("ElvUI" ) == true then  
+	if EMAPrivate.Core.IsAddOnLoaded("ElvUI" ) == true then  
 		frame:SetPoint("BOTTOMLEFT", QuestLogFrame, "BOTTOMLEFT", 40, -80)
 	else
 		local _, _, _, tocversion = GetBuildInfo()


### PR DESCRIPTION
Update modules to use API compatibility functions

- DisplayTeam.lua: Replace C_AddOns.IsAddOnLoaded with EMAPrivate.Core.IsAddOnLoaded
  - Line 29: TrufiGCD initialization
  - Lines 3263, 3280: TrufiGCD integration checks
  
- Quest-Classic.lua: Replace IsAddOnLoaded with EMAPrivate.Core.IsAddOnLoaded
  - Line 1959: ElvUI detection for frame positioning

Enables cross-version compatibility by using the compatibility wrapper functions 
exported by Core.lua. Fixes 34 nil value errors in TBC Anniversary (DisplayTeam:29 x32, Quest-Classic:1954 x2).

**Depends on:** PR #142, PR #143